### PR TITLE
Updates to Rails and Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 inherit_gem:
-  rubocop-rails:
+  rubocop-rails_config:
     - config/rails.yml
 
 AllCops:

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ ruby "2.5.0"
 
 gem "dotenv-rails", groups: [:development, :test]
 
-gem "rails", "5.2.0"
+gem "rails", github: "rails/rails", branch: "5-2-stable"
 gem "activerecord-session_store"
 gem "pg"
 gem "puma"
@@ -28,7 +28,7 @@ group :development, :test do
   gem "pry"
   gem "pry-doc"
   gem "rails-controller-testing"
-  gem "rubocop-rails"
+  gem "rubocop-rails_config"
   gem "simplecov", require: false
   gem "spring"
   gem "spring-watcher-listen", "~> 2.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,7 @@
 GIT
-  remote: git://github.com/rsl/stringex.git
-  revision: a637b6b3242a4ffc3ad9542130fa9a351a6277d4
-  specs:
-    stringex (2.8.4)
-
-GEM
-  remote: https://rubygems.org/
+  remote: git://github.com/rails/rails.git
+  revision: eca9651f10debd57839185458b377f23fc5ddd3b
+  branch: 5-2-stable
   specs:
     actioncable (5.2.0)
       actionpack (= 5.2.0)
@@ -39,12 +35,6 @@ GEM
       activemodel (= 5.2.0)
       activesupport (= 5.2.0)
       arel (>= 9.0)
-    activerecord-session_store (1.1.1)
-      actionpack (>= 4.0)
-      activerecord (>= 4.0)
-      multi_json (~> 1.11, >= 1.11.2)
-      rack (>= 1.5.2, < 3)
-      railties (>= 4.0)
     activestorage (5.2.0)
       actionpack (= 5.2.0)
       activerecord (= 5.2.0)
@@ -54,6 +44,41 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    rails (5.2.0)
+      actioncable (= 5.2.0)
+      actionmailer (= 5.2.0)
+      actionpack (= 5.2.0)
+      actionview (= 5.2.0)
+      activejob (= 5.2.0)
+      activemodel (= 5.2.0)
+      activerecord (= 5.2.0)
+      activestorage (= 5.2.0)
+      activesupport (= 5.2.0)
+      bundler (>= 1.3.0)
+      railties (= 5.2.0)
+      sprockets-rails (>= 2.0.0)
+    railties (5.2.0)
+      actionpack (= 5.2.0)
+      activesupport (= 5.2.0)
+      method_source
+      rake (>= 0.8.7)
+      thor (>= 0.19.0, < 2.0)
+
+GIT
+  remote: git://github.com/rsl/stringex.git
+  revision: a637b6b3242a4ffc3ad9542130fa9a351a6277d4
+  specs:
+    stringex (2.8.4)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activerecord-session_store (1.1.1)
+      actionpack (>= 4.0)
+      activerecord (>= 4.0)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0)
     arel (9.0.0)
     ast (2.4.0)
     better_errors (2.4.0)
@@ -69,19 +94,20 @@ GEM
     debug_inspector (0.0.3)
     diffy (3.2.1)
     docile (1.3.1)
-    dotenv (2.4.0)
-    dotenv-rails (2.4.0)
-      dotenv (= 2.4.0)
+    dotenv (2.5.0)
+    dotenv-rails (2.5.0)
+      dotenv (= 2.5.0)
       railties (>= 3.2, < 6.0)
     erubi (1.7.1)
-    ffi (1.9.23)
+    ffi (1.9.25)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.1)
     json (2.1.0)
     jwt (2.1.0)
-    kramdown (1.16.2)
+    kramdown (1.17.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -103,38 +129,25 @@ GEM
       railties (~> 5.0)
     multi_json (1.13.1)
     nio4r (2.3.1)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
-    parser (2.5.1.0)
+    parser (2.5.1.2)
       ast (~> 2.4.0)
     pg (1.0.0)
-    powerpack (0.1.1)
+    powerpack (0.1.2)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     pry-doc (0.13.4)
       pry (~> 0.11)
       yard (~> 0.9.11)
-    puma (3.11.4)
+    puma (3.12.0)
     rack (2.0.5)
     rack-proxy (0.6.4)
       rack
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
-    rails (5.2.0)
-      actioncable (= 5.2.0)
-      actionmailer (= 5.2.0)
-      actionpack (= 5.2.0)
-      actionview (= 5.2.0)
-      activejob (= 5.2.0)
-      activemodel (= 5.2.0)
-      activerecord (= 5.2.0)
-      activestorage (= 5.2.0)
-      activesupport (= 5.2.0)
-      bundler (>= 1.3.0)
-      railties (= 5.2.0)
-      sprockets-rails (>= 2.0.0)
     rails-controller-testing (1.0.2)
       actionpack (~> 5.x, >= 5.0.1)
       actionview (~> 5.x, >= 5.0.1)
@@ -144,25 +157,20 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
-    railties (5.2.0)
-      actionpack (= 5.2.0)
-      activesupport (= 5.2.0)
-      method_source
-      rake (>= 0.8.7)
-      thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     rake (12.3.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rubocop (0.56.0)
+    rubocop (0.58.1)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.5)
+      parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-rails (1.4.1)
+    rubocop-rails_config (0.1.3)
       railties (>= 3.0)
       rubocop (~> 0.53)
     ruby-progressbar (1.9.0)
@@ -177,7 +185,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -188,15 +196,15 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    unicode-display_width (1.3.2)
-    webpacker (3.5.3)
+    unicode-display_width (1.4.0)
+    webpacker (3.5.5)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
-    yard (0.9.12)
+    yard (0.9.15)
 
 PLATFORMS
   ruby
@@ -216,9 +224,9 @@ DEPENDENCIES
   pry
   pry-doc
   puma
-  rails (= 5.2.0)
+  rails!
   rails-controller-testing
-  rubocop-rails
+  rubocop-rails_config
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)


### PR DESCRIPTION
No longer a need for monkeypatch but, still a stable version of Rails
rubocop-rails changed names

![](https://media2.giphy.com/media/eCDb0H7YP2Fz2/giphy.gif)